### PR TITLE
Fix extension key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	},
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "news"
+			"extension-key": "no_sudo_mode"
 		}
 	}
 }


### PR DESCRIPTION
I just realized, there is the wrong extension key defined in "composer.json". This means, the configuration is located in the "news" namespace instead of the correct "no_sudo_mode" namespace.

<img src="https://github.com/user-attachments/assets/09f9f191-bb84-444a-a121-5f3296dbe6bc" />

In the EventListener class itsself, the correct configuration namespace is requested, which always leads to an empty array as return of `getExtensionConfiguration()` method

https://github.com/georgringer/no_sudo_mode/blob/e1328648138a18d19ec16eb9fb1c8ff93072dd50/Classes/EventListener/BypassSudoModeEventListener.php#L35

This pull requests changes the extension key in "composer.json" to the correct value "no_sudo_mode"

