### PR TITLE
Strengthen default DDEV domain pattern

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,2 +1,2 @@
 # cat=import module/1; type=string; label=Skip for domaisn
-skipDomains = |.*\.ddev.site|,|^internal\.example\.com$|
+skipDomains = |.*\.ddev\.site$|,|^internal\.example\.com$|


### PR DESCRIPTION
The old pattern `.*\.ddev.site` would allow the pattern anywhere in the string. And the unescaped dot character `.` would be a placeholder for any character.

The updated pattern `.*\.ddev\.site$` is more strict and really requires the string ".ddev.site" to be the end of the domain.